### PR TITLE
Replace single quotes with grave accent.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # SE761
 SOFTENG761
 
-1. 'cd' to your intended directory\
-2. type in 'git clone https://github.com/toyman93/CrystalTickets.git' in the termianl/command line\
-3. type in 'cd CrystalTickets'\
-4. tyep in 'git checkout PROTOTYPE'\
-5. type in 'git pull'\
-6. Open Unity application\
-7. Set the work directory to the downloaded directory in Unity\
-8. Press the play(triangle) button on the top to play this game. Have fun!}
+1. `cd` to your intended directory
+2. type in `git clone https://github.com/toyman93/CrystalTickets.git` in the termianl/command line
+3. type in `cd CrystalTickets`
+4. tyep in `git checkout PROTOTYPE`
+5. type in `git pull`
+6. Open Unity application
+7. Set the work directory to the downloaded directory in Unity
+8. Press the play(triangle) button on the top to play this game. Have fun!


### PR DESCRIPTION
Markdown requires ` to show staff as cod block.
